### PR TITLE
Fix graphql-server test snapshot

### DIFF
--- a/server/test/__snapshots__/graphql-server.test.js.snap
+++ b/server/test/__snapshots__/graphql-server.test.js.snap
@@ -56,7 +56,11 @@ Object {
 exports[`GraphQL server Queries should filter results by ingredient ID 1`] = `
 Object {
   "data": Object {
-    "recipes": Array [],
+    "recipes": Array [
+      Object {
+        "title": "Wiener Schnitzel",
+      },
+    ],
   },
 }
 `;


### PR DESCRIPTION
This fixes the empty snapshot for the `should filter results by ingredient ID` spec.